### PR TITLE
SmokingArea API 내부에서 Town과 같이 동작하도록 수정

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/common/GlobalException.kt
+++ b/src/main/kotlin/com/hsik/smoking/common/GlobalException.kt
@@ -5,6 +5,7 @@ open class HumanException(
 ) : RuntimeException(message)
 
 class ResourceNotFoundException(
-    id: String,
-    resource: String,
-) : HumanException("$[ID: $id]를 가진 $resource 가 존재하지 않습니다.")
+    message: String,
+) : HumanException(message) {
+    constructor(id: String, resource: String) : this("$[ID: $id]를 가진 $resource 가 존재하지 않습니다.")
+}

--- a/src/main/kotlin/com/hsik/smoking/common/RelationshipValidator.kt
+++ b/src/main/kotlin/com/hsik/smoking/common/RelationshipValidator.kt
@@ -1,0 +1,10 @@
+package com.hsik.smoking.common
+
+import com.hsik.smoking.domain.area.SmokingArea
+
+fun SmokingArea.relativeOrThrow(townId: String): SmokingArea {
+    if (this.townId.toString() != townId) {
+        throw ResourceNotFoundException("SmokingArea 의 ${this.townId}와 입력한 ${townId}가 일치하지 않습니다.")
+    }
+    return this
+}

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingArea.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingArea.kt
@@ -19,6 +19,9 @@ class SmokingArea(
     var id: ObjectId = ObjectId()
         private set
 
+    var townId: ObjectId? = null
+        private set
+
     /**
      * 생성 시각
      */
@@ -66,6 +69,11 @@ class SmokingArea(
      * 운영 상태 변경 이유
      */
     var cause: String? = null
+
+    fun setTown(townId: ObjectId): SmokingArea {
+        this.townId = townId
+        return this
+    }
 
     enum class Status(
         val desc: String,

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
@@ -1,6 +1,7 @@
 package com.hsik.smoking.domain.area
 
 import com.hsik.smoking.common.ResourceNotFoundException
+import com.hsik.smoking.common.relativeOrThrow
 import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
 import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
@@ -12,6 +13,11 @@ class SmokingAreaFinder(
 ) {
     fun findById(id: String): SmokingArea =
         smokingAreaRepository.findByIdOrNull(ObjectId(id)) ?: throw ResourceNotFoundException(id, RESOURCE)
+
+    fun findByTownIdAndAreaId(
+        townId: String,
+        areaId: String,
+    ): SmokingArea = findById(areaId).relativeOrThrow(townId)
 
     companion object {
         const val RESOURCE = "흡연소"

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaService.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaService.kt
@@ -1,15 +1,22 @@
 package com.hsik.smoking.domain.area
 
 import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
+import com.hsik.smoking.domain.town.TownFinder
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 
 @Service
 class SmokingAreaService(
     private val smokingAreaRepository: SmokingAreaRepository,
+    private val townFinder: TownFinder,
 ) {
-    fun add(address: String): ObjectId {
+    fun add(
+        townId: String,
+        address: String,
+    ): ObjectId {
         val area = SmokingArea(address)
+        val town = townFinder.findById(townId)
+        town.add(area)
         return smokingAreaRepository.save(area).id
     }
 }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
@@ -12,16 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/v1/areas")
+@RequestMapping("/v1/towns/{townId}/areas")
 class SmokingAreaController(
     private val smokingAreaFinder: SmokingAreaFinder,
     private val smokingAreaService: SmokingAreaService,
 ) {
-    @GetMapping("/{id}")
+    @GetMapping("/{areaId}")
     fun findOne(
-        @PathVariable("id") id: String,
+        @PathVariable("townId") townId: String,
+        @PathVariable("areaId") areaId: String,
     ): Reply<SmokingAreaResources.Response.Me> {
-        val area = smokingAreaFinder.findById(id)
+        val area = smokingAreaFinder.findByTownIdAndAreaId(townId, areaId)
         return SmokingAreaResources.Response.Me
             .from(area)
             .toReply()
@@ -29,10 +30,11 @@ class SmokingAreaController(
 
     @PostMapping
     fun add(
+        @PathVariable("townId") townId: String,
         @RequestBody request: SmokingAreaResources.Request.Me,
     ): Reply<String> =
         smokingAreaService
-            .add(request.address)
+            .add(townId, request.address)
             .toString()
             .toReply()
 }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaResources.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaResources.kt
@@ -17,6 +17,7 @@ class SmokingAreaResources {
             val modifiedAt: LocalDateTime,
             val status: SmokingArea.Status,
             val address: String,
+            val townId: String? = null,
             val metaUpdateDateTime: LocalDateTime? = null,
             val latitude: Double? = null,
             val longitude: Double? = null,
@@ -26,19 +27,22 @@ class SmokingAreaResources {
         ) {
             companion object {
                 fun from(area: SmokingArea): Me =
-                    Me(
-                        id = area.id.toString(),
-                        createdAt = area.createdAt,
-                        modifiedAt = area.modifiedAt,
-                        status = area.status,
-                        address = area.address,
-                        metaUpdateDateTime = area.metadataUpdateDateTime,
-                        latitude = area.latitude,
-                        longitude = area.longitude,
-                        manager = area.manager,
-                        description = area.description,
-                        cause = area.cause,
-                    )
+                    area.run {
+                        Me(
+                            id = id.toString(),
+                            createdAt = createdAt,
+                            modifiedAt = modifiedAt,
+                            status = status,
+                            address = address,
+                            townId = townId.toString(),
+                            metaUpdateDateTime = metadataUpdateDateTime,
+                            latitude = latitude,
+                            longitude = longitude,
+                            manager = manager,
+                            description = description,
+                            cause = cause,
+                        )
+                    }
             }
         }
     }

--- a/src/main/kotlin/com/hsik/smoking/domain/town/Town.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/Town.kt
@@ -59,5 +59,6 @@ class Town(
 
     fun add(smokingArea: SmokingArea) {
         this.smokingAreas.add(smokingArea)
+        smokingArea.setTown(this.id)
     }
 }

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerFlow.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerFlow.kt
@@ -12,8 +12,11 @@ import org.springframework.test.web.servlet.post
 class AreaControllerFlow(
     private val mockMvc: MockMvc,
 ) {
-    fun findOne(id: String): SmokingAreaResources.Response.Me {
-        val uri = linkTo<SmokingAreaController> { findOne(id) }.toUri()
+    fun findOne(
+        townId: String,
+        areaId: String,
+    ): SmokingAreaResources.Response.Me {
+        val uri = linkTo<SmokingAreaController> { findOne(townId, areaId) }.toUri()
         return mockMvc
             .get(uri)
             .andExpect {
@@ -25,9 +28,12 @@ class AreaControllerFlow(
             .content
     }
 
-    fun add(address: String): String {
+    fun add(
+        townId: String,
+        address: String,
+    ): String {
         val request = SmokingAreaResources.Request.Me(address)
-        val uri = linkTo<SmokingAreaController> { add(request) }.toUri()
+        val uri = linkTo<SmokingAreaController> { add(townId, request) }.toUri()
         return mockMvc
             .post(uri) {
                 contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerTest.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerTest.kt
@@ -1,23 +1,28 @@
 package com.hsik.smoking.domain.area.api
 
 import com.hsik.smoking.config.FlowTest
+import com.hsik.smoking.domain.town.api.TownControllerFlow
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
 class AreaControllerTest : FlowTest() {
-    @DisplayName("흡연소 생성/조회 테스트")
+    @DisplayName("흡연 구역 생성/조회 테스트")
     @Test
     fun areaCrTest() {
-        val areaControllerFlow = AreaControllerFlow(mockMvc)
+        // Given
+        // 도시 생성
+        val townControllerFlow = TownControllerFlow(mockMvc)
+        val townId = townControllerFlow.add("테스트구")
 
-        // 생성
+        // 흡연 구역 생성
+        val areaControllerFlow = AreaControllerFlow(mockMvc)
         val address = "서울특별시 동대문구 무학로 테스트길 1-1"
-        val id: String = assertDoesNotThrow { areaControllerFlow.add(address) }
+        val id: String = assertDoesNotThrow { areaControllerFlow.add(townId, address) }
 
         // 단일 조회
-        val area = areaControllerFlow.findOne(id)
+        val area = areaControllerFlow.findOne(townId, id)
         area.id shouldBe id
         area.address shouldBe address
     }


### PR DESCRIPTION
# 변경 사항
- SmokingArea API URL에 TownId 추가
  - 어느 지역의 흡연 구역인지 알기 위함
- SmokingArea API 내부에서 Town과 같이 동작하도록 수정
  - 조회 시 Town에 속해있는 SmokingArea 이도록 함
  - 추가 시 속해야 하는 Town을 설정