### PR TITLE
패키지 구조 변경

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/common/RelationshipValidator.kt
+++ b/src/main/kotlin/com/hsik/smoking/common/RelationshipValidator.kt
@@ -1,6 +1,6 @@
 package com.hsik.smoking.common
 
-import com.hsik.smoking.domain.area.SmokingArea
+import com.hsik.smoking.domain.town.area.SmokingArea
 
 fun SmokingArea.relativeOrThrow(townId: String): SmokingArea {
     if (this.townId.toString() != townId) {

--- a/src/main/kotlin/com/hsik/smoking/domain/town/Town.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/Town.kt
@@ -1,6 +1,6 @@
 package com.hsik.smoking.domain.town
 
-import com.hsik.smoking.domain.area.SmokingArea
+import com.hsik.smoking.domain.town.area.SmokingArea
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.DBRef

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingArea.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingArea.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area
+package com.hsik.smoking.domain.town.area
 
 import org.bson.types.ObjectId
 import org.springframework.data.annotation.Id

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingAreaFinder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingAreaFinder.kt
@@ -1,8 +1,8 @@
-package com.hsik.smoking.domain.area
+package com.hsik.smoking.domain.town.area
 
 import com.hsik.smoking.common.ResourceNotFoundException
 import com.hsik.smoking.common.relativeOrThrow
-import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
+import com.hsik.smoking.domain.town.area.repository.SmokingAreaRepository
 import org.bson.types.ObjectId
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingAreaService.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/SmokingAreaService.kt
@@ -1,7 +1,7 @@
-package com.hsik.smoking.domain.area
+package com.hsik.smoking.domain.town.area
 
-import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
 import com.hsik.smoking.domain.town.TownFinder
+import com.hsik.smoking.domain.town.area.repository.SmokingAreaRepository
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/api/SmokingAreaController.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/api/SmokingAreaController.kt
@@ -1,9 +1,9 @@
-package com.hsik.smoking.domain.area.api
+package com.hsik.smoking.domain.town.area.api
 
 import com.hsik.smoking.common.Reply
 import com.hsik.smoking.common.toReply
-import com.hsik.smoking.domain.area.SmokingAreaFinder
-import com.hsik.smoking.domain.area.SmokingAreaService
+import com.hsik.smoking.domain.town.area.SmokingAreaFinder
+import com.hsik.smoking.domain.town.area.SmokingAreaService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/api/SmokingAreaResources.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/api/SmokingAreaResources.kt
@@ -1,6 +1,6 @@
-package com.hsik.smoking.domain.area.api
+package com.hsik.smoking.domain.town.area.api
 
-import com.hsik.smoking.domain.area.SmokingArea
+import com.hsik.smoking.domain.town.area.SmokingArea
 import java.time.LocalDateTime
 
 class SmokingAreaResources {

--- a/src/main/kotlin/com/hsik/smoking/domain/town/area/repository/SmokingAreaRepository.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/area/repository/SmokingAreaRepository.kt
@@ -1,6 +1,6 @@
-package com.hsik.smoking.domain.area.repository
+package com.hsik.smoking.domain.town.area.repository
 
-import com.hsik.smoking.domain.area.SmokingArea
+import com.hsik.smoking.domain.town.area.SmokingArea
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/DummyOpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/DummyOpenDataPortalClient.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area.client
+package com.hsik.smoking.domain.town.client
 
 import kotlin.random.Random
 

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalClient.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area.client
+package com.hsik.smoking.domain.town.client
 
 interface OpenDataPortalClient {
     fun findAllSmokingAreaByDongDaemungu(): List<OpenDataPortalResources.SmokingArea.DongDaeMunGu>

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalConfiguration.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalConfiguration.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area.client
+package com.hsik.smoking.domain.town.client
 
 import com.hsik.smoking.config.AppEnvironment
 import com.hsik.smoking.util.RestClient

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalResources.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalResources.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area.client
+package com.hsik.smoking.domain.town.client
 
 import com.fasterxml.jackson.annotation.JsonAlias
 

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/StableOpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/StableOpenDataPortalClient.kt
@@ -1,4 +1,4 @@
-package com.hsik.smoking.domain.area.client
+package com.hsik.smoking.domain.town.client
 
 import com.hsik.smoking.config.AppEnvironment
 import com.hsik.smoking.util.RestClient

--- a/src/test/kotlin/com/hsik/smoking/client/MongoDbClientTest.kt
+++ b/src/test/kotlin/com/hsik/smoking/client/MongoDbClientTest.kt
@@ -1,7 +1,7 @@
 package com.hsik.smoking.client
 
 import com.hsik.smoking.config.FlowTest
-import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
+import com.hsik.smoking.domain.town.area.repository.SmokingAreaRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerFlow.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/AreaControllerFlow.kt
@@ -1,6 +1,8 @@
 package com.hsik.smoking.domain.area.api
 
 import com.hsik.smoking.common.Reply
+import com.hsik.smoking.domain.town.area.api.SmokingAreaController
+import com.hsik.smoking.domain.town.area.api.SmokingAreaResources
 import com.hsik.smoking.util.fromJson
 import com.hsik.smoking.util.toJson
 import org.springframework.hateoas.server.mvc.linkTo


### PR DESCRIPTION
# 변경 사항
Area 패키지를 Town 패키지 안으로 이동

# Why?
- Area 패키지와 Town 패키지의 순환 참조 제거
  - 패키지가 순환 구조를 이루면, 나중에 서비스가 커질 경우 서비스를 분리하기 어렵다.
    - 예를 들어 서비스가 커져서 A,B,C 패키지가 있고, 서로 순환 참조를 하고 있다고 해보자.
      - 이럴 경우 각 패키지의 클래스를 서로 참조하고 있어서 패키지를 삭제하는 순간 변경해야 하는 클래스의 수가 매우 클 것이다.
      - 하지만 A,B,C 모두가 순환 참조를 하고 있지 않을 경우 패키지 수정으로 인한 영향이 적다.
- 리소스의 계층에 맞춰 패키지를 구조화함으로써 읽는 사람의 가독성 증가