### PR TITLE
공공 데이터 API 응답 클래스명 수정

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/DummyOpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/DummyOpenDataPortalClient.kt
@@ -3,9 +3,9 @@ package com.hsik.smoking.domain.town.client
 import kotlin.random.Random
 
 class DummyOpenDataPortalClient : OpenDataPortalClient {
-    override fun findAllSmokingAreaByDongDaemungu(): List<OpenDataPortalResources.SmokingArea.DongDaeMunGu> =
+    override fun findAllSmokingAreaInDongdaemunGu(): List<OpenDataPortalResources.SmokingArea.DongdaemunGu> =
         listOf(
-            OpenDataPortalResources.SmokingArea.DongDaeMunGu(
+            OpenDataPortalResources.SmokingArea.DongdaemunGu(
                 id = Random.nextLong(),
                 type = "완전폐쇄형",
                 address = "무학로 테스트길 36로 옥상",
@@ -15,7 +15,7 @@ class DummyOpenDataPortalClient : OpenDataPortalClient {
                 manager = "테스트 카페",
                 metadataUpdateDateTime = "2021-10-27",
             ),
-            OpenDataPortalResources.SmokingArea.DongDaeMunGu(
+            OpenDataPortalResources.SmokingArea.DongdaemunGu(
                 id = Random.nextLong(),
                 type = "개방형",
                 address = "무학로 테스트길 26로 1층",

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalClient.kt
@@ -1,5 +1,5 @@
 package com.hsik.smoking.domain.town.client
 
 interface OpenDataPortalClient {
-    fun findAllSmokingAreaByDongDaemungu(): List<OpenDataPortalResources.SmokingArea.DongDaeMunGu>
+    fun findAllSmokingAreaInDongdaemunGu(): List<OpenDataPortalResources.SmokingArea.DongdaemunGu>
 }

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalResources.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/OpenDataPortalResources.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAlias
 
 class OpenDataPortalResources {
     class SmokingArea {
-        data class DongDaeMunGu(
+        data class DongdaemunGu(
             @JsonAlias("연번")
             val id: Long,
             @JsonAlias("시설형태")

--- a/src/main/kotlin/com/hsik/smoking/domain/town/client/StableOpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/town/client/StableOpenDataPortalClient.kt
@@ -8,12 +8,12 @@ class StableOpenDataPortalClient(
     private val env: AppEnvironment.OpenDataPortal,
     private val restClient: RestClient,
 ) : OpenDataPortalClient {
-    override fun findAllSmokingAreaByDongDaemungu(): List<OpenDataPortalResources.SmokingArea.DongDaeMunGu> {
+    override fun findAllSmokingAreaInDongdaemunGu(): List<OpenDataPortalResources.SmokingArea.DongdaemunGu> {
         // TODO 실제 URI 작성 및 호출에 사용할 API 인증키 설정 필요
         val uri = "${env.host}/test"
 
         return restClient
             .get(uri)
-            .fromJson<List<OpenDataPortalResources.SmokingArea.DongDaeMunGu>>()
+            .fromJson<List<OpenDataPortalResources.SmokingArea.DongdaemunGu>>()
     }
 }


### PR DESCRIPTION
동대문이 고유 명사이므로 클래스 이름을 `DongDaeMunGu`에서 `DongdaemunGu`로 변경