### PR TITLE
흡연 구역 검색 API 구현

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
@@ -3,16 +3,24 @@ package com.hsik.smoking.domain.area
 import com.hsik.smoking.common.ResourceNotFoundException
 import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
 import org.bson.types.ObjectId
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class SmokingAreaFinder(
     private val smokingAreaRepository: SmokingAreaRepository,
+    private val mongoTemplate: MongoTemplate,
 ) {
-    fun findAll(): List<SmokingArea> = smokingAreaRepository.findAll()
-
-    fun findAllByTownName(name: SmokingArea.TownName): List<SmokingArea> = smokingAreaRepository.findAllByName(name)
+    fun search(townName: SmokingArea.TownName? = null): List<SmokingArea> {
+        val query =
+            Query().apply {
+                townName?.let { Criteria.where("name").`is`(it) }
+            }
+        return mongoTemplate.find(query, SmokingArea::class.java)
+    }
 
     fun findById(id: String): SmokingArea =
         smokingAreaRepository.findByIdOrNull(ObjectId(id)) ?: throw ResourceNotFoundException("ID", id, RESOURCE)

--- a/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
@@ -24,18 +24,8 @@ class SmokingAreaController(
     private val smokingAreaSyncService: SmokingAreaSyncService,
 ) {
     @GetMapping
-    fun findAll(): Replies<SmokingAreaResources.Response.Me> {
-        val areas = smokingAreaFinder.findAll()
-        return SmokingAreaResources.Response.Me
-            .from(areas)
-            .toReplies()
-    }
-
-    @GetMapping("/name/{name}")
-    fun findAllByTownName(
-        @PathVariable name: SmokingArea.TownName,
-    ): Replies<SmokingAreaResources.Response.Me> {
-        val areas = smokingAreaFinder.findAllByTownName(name)
+    fun search(townName: SmokingArea.TownName? = null): Replies<SmokingAreaResources.Response.Me> {
+        val areas = smokingAreaFinder.search(townName)
         return SmokingAreaResources.Response.Me
             .from(areas)
             .toReplies()

--- a/src/main/kotlin/com/hsik/smoking/domain/area/repository/SmokingAreaRepository.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/repository/SmokingAreaRepository.kt
@@ -4,6 +4,4 @@ import com.hsik.smoking.domain.area.SmokingArea
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface SmokingAreaRepository : MongoRepository<SmokingArea, ObjectId> {
-    fun findAllByName(townName: SmokingArea.TownName): List<SmokingArea>
-}
+interface SmokingAreaRepository : MongoRepository<SmokingArea, ObjectId>

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaControllerFlow.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaControllerFlow.kt
@@ -15,22 +15,8 @@ import org.springframework.test.web.servlet.put
 class SmokingAreaControllerFlow(
     private val mockMvc: MockMvc,
 ) {
-    fun findAll(): List<SmokingAreaResources.Response.Me> {
-        val uri = linkTo<SmokingAreaController> { findAll() }.toUri()
-        return mockMvc
-            .get(uri)
-            .andExpect {
-                status { is2xxSuccessful() }
-            }.andReturn()
-            .response
-            .contentAsString
-            .fromJson<Replies<SmokingAreaResources.Response.Me>>()
-            .collection
-            .toList()
-    }
-
-    fun findAllByName(name: SmokingArea.TownName): List<SmokingAreaResources.Response.Me> {
-        val uri = linkTo<SmokingAreaController> { findAllByTownName(name) }.toUri()
+    fun search(townName: SmokingArea.TownName? = null): List<SmokingAreaResources.Response.Me> {
+        val uri = linkTo<SmokingAreaController> { search(townName) }.toUri()
         return mockMvc
             .get(uri)
             .andExpect {

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaControllerTest.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaControllerTest.kt
@@ -37,11 +37,11 @@ class SmokingAreaControllerTest : FlowTest() {
         area.address shouldBe address1
 
         // 전체 조회
-        val allOfSmokingAreas = smokingAreaControllerFlow.findAll()
+        val allOfSmokingAreas = smokingAreaControllerFlow.search()
         allOfSmokingAreas.shouldForExactly(2) { it.id == id1 || it.id == id2 }
 
         // 이름으로 전체 조회
-        val smokingAreas = smokingAreaControllerFlow.findAllByName(name)
+        val smokingAreas = smokingAreaControllerFlow.search(name)
         allOfSmokingAreas.shouldForExactly(2) { it.id == id1 || it.id == id2 }
         smokingAreas.shouldForAll { it.townName shouldBe name }
     }


### PR DESCRIPTION
# 변경 사항
- 특정 도시에 속한 흡연 구역을 조회하는 API 구현
- `GET /v1/areas/name/{name}`  API 삭제

# Why?
- 해당 API는 RESTful에 맞지 않다고 생각
  - PathVariable로 특정 도시에 속한 흡연 구역을 가져오기 위해 해당 API를 만들었음
  - GET으로 응답받는 컬렉션들 중 특정한 리소스들만을 보고 싶다면 쿼리 파라미터로 식별하는 게 맞음
  > The query component contains non-hierarchical data that, along with data in the path component ([Section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)), serves to identify a resource within the scope of the URI's schem 