### PR TITLE
GitHub Actions에서 Dev 브랜치도 Gradle을 캐싱하도록 설정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          # Only write to the cache for builds on the 'main' and 'release' branches. (Default is 'main' only.)
+          # Builds on other branches will only read existing entries from the cache.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build


### PR DESCRIPTION
### Why?
main에서만 되고 있는 Gradle 캐시를 dev에서도 캐싱하도록 설정한다.

gradle/actions/setup-gradle은 GitHub Actions Runner에 Gradle을 설치하고 설정하는 Actions이다.
해당 Actions는 `main/master` 브랜치에 새로운 코드가 커밋될 경우 Gradle 디렉토리를 캐싱한다.
그 후 `main/master` 가 아닌 다른 브랜치에서 Workflow가 실행될 경우 캐싱된 Gradle을 사용하려고 한다.

문제는 `main/master`가 아닌 다른 브랜치에서는 캐시를 업데이트하지 않는다.
그래서 `dev`와 같은 또 다른 장기 브랜치가 존재하는 경우 main과 dev의 Gradle이 다를 경우 캐싱된 Gradle을 사용하지 못한다.

Workflow의 Gradle Summary를 확인해보면, 캐싱된 데이터를 사용하지 못하는 것을 확인할 수 있다.
![스크린샷 2024-10-17 오후 10 50 52](https://github.com/user-attachments/assets/ce7385fb-4a6e-440a-905d-f82050db362b)

dev에서도 캐싱하도록 설정하여 dev에서 분기된 브랜치들이 캐싱된 Gradle을 사용하여 빌드 속도를 향상시킨다.
