### PR TITLE
흡연 구역 조회 데이터 캐싱

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-undertow") {
@@ -67,6 +68,8 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.2"))
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mongodb")
+    testImplementation("com.redis:testcontainers-redis:2.2.2")
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
 
     // Other
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")

--- a/src/main/kotlin/com/hsik/smoking/config/RedisConfiguration.kt
+++ b/src/main/kotlin/com/hsik/smoking/config/RedisConfiguration.kt
@@ -1,0 +1,54 @@
+package com.hsik.smoking.config
+
+import io.lettuce.core.SocketOptions
+import io.lettuce.core.cluster.ClusterClientOptions
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisClusterConfiguration
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+@Configuration
+@EnableConfigurationProperties(RedisProperties::class)
+@EnableRedisRepositories
+class RedisConfiguration(
+    private val properties: RedisProperties,
+) {
+    @Bean
+    fun stringRedisTemplate(): StringRedisTemplate {
+        val clientConfiguration =
+            LettuceClientConfiguration
+                .builder()
+                .commandTimeout(properties.timeout)
+                .clientOptions(
+                    ClusterClientOptions
+                        .builder()
+                        .autoReconnect(true)
+                        .socketOptions(
+                            SocketOptions
+                                .builder()
+                                .connectTimeout(properties.connectTimeout)
+                                .keepAlive(true)
+                                .build(),
+                        ).topologyRefreshOptions(
+                            ClusterTopologyRefreshOptions
+                                .builder()
+                                .enablePeriodicRefresh(properties.lettuce.cluster.refresh.period)
+                                .build(),
+                        ).build(),
+                ).build()
+
+        val clusterConfiguration =
+            RedisClusterConfiguration(properties.cluster.nodes)
+                .apply { password = RedisPassword.of(properties.password) }
+
+        val factory = LettuceConnectionFactory(clusterConfiguration, clientConfiguration).apply { afterPropertiesSet() }
+        return StringRedisTemplate(factory)
+    }
+}

--- a/src/main/kotlin/com/hsik/smoking/domain/area/Geocoder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/Geocoder.kt
@@ -1,19 +1,33 @@
 package com.hsik.smoking.domain.area
 
 import com.hsik.smoking.domain.client.kakao.KakaoClient
+import org.springframework.stereotype.Component
 
+@Component
 class Geocoder(
+    private val smokingAreaCacheStore: SmokingAreaCacheStore,
     private val kakaoClient: KakaoClient,
-    private val smokingAreas: List<SmokingArea>,
 ) {
-    fun searchByAddress(): List<SmokingArea> {
+    fun searchByAddress(smokingAreas: List<SmokingArea>): List<SmokingArea> {
         for (smokingArea in smokingAreas) {
+            // Use cache data if exists
+            if (smokingAreaCacheStore.hasKey(smokingArea.id)) {
+                val cachedSmokingArea = smokingAreaCacheStore.getValue(smokingArea.id)
+                smokingArea.latitude = cachedSmokingArea.latitude!!.toDouble()
+                smokingArea.longitude = cachedSmokingArea.longitude!!.toDouble()
+                continue
+            }
+
+            // Call kakao client
             kakaoClient
                 .geocoding(smokingArea.address)
                 ?.let {
                     smokingArea.latitude = it.latitude.toDouble()
                     smokingArea.longitude = it.longitude.toDouble()
                 }
+
+            // Store data in cache
+            smokingAreaCacheStore.set(smokingArea.id, smokingArea)
         }
         return smokingAreas
     }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaCacheStore.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaCacheStore.kt
@@ -1,0 +1,54 @@
+package com.hsik.smoking.domain.area
+
+import com.hsik.smoking.util.fromJson
+import com.hsik.smoking.util.toJson
+import org.bson.types.ObjectId
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class SmokingAreaCacheStore(
+    private val stringRedisTemplate: StringRedisTemplate,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun hasKey(key: ObjectId): Boolean {
+        val smokingAreaRedisKey = SmokingAreaKey().getKeyOfSmokingArea(key)
+        try {
+            return stringRedisTemplate.hasKey(smokingAreaRedisKey)
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache read failed: {}", smokingAreaRedisKey, e)
+            throw Exception(e)
+        }
+    }
+
+    fun getValue(key: ObjectId): SmokingArea {
+        val smokingAreaRedisKey = SmokingAreaKey().getKeyOfSmokingArea(key)
+        try {
+            val value = stringRedisTemplate.opsForValue().get(smokingAreaRedisKey)
+            if (value.isNullOrBlank()) {
+                throw IllegalStateException("[CACHE] Redis does not have key : $smokingAreaRedisKey")
+            }
+
+            return value.fromJson<SmokingArea>()
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache read failed: {}", smokingAreaRedisKey, e)
+            throw Exception(e)
+        }
+    }
+
+    fun set(
+        key: ObjectId,
+        smokingArea: SmokingArea,
+    ) {
+        val smokingAreaRedisKey = SmokingAreaKey().getKeyOfSmokingArea(key)
+        try {
+            val result = stringRedisTemplate.opsForValue().setIfAbsent(smokingAreaRedisKey, smokingArea.toJson())
+            logger.debug("[CACHE] Redis cache set key:{}, result: {}", smokingAreaRedisKey, result)
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache set failed: {}", smokingAreaRedisKey, e)
+            throw Exception(e)
+        }
+    }
+}

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaFinder.kt
@@ -2,11 +2,7 @@ package com.hsik.smoking.domain.area
 
 import com.hsik.smoking.common.ResourceNotFoundException
 import com.hsik.smoking.domain.area.repository.SmokingAreaRepository
-import com.hsik.smoking.domain.client.kakao.KakaoClient
 import org.bson.types.ObjectId
-import org.springframework.data.mongodb.core.MongoTemplate
-import org.springframework.data.mongodb.core.query.Criteria
-import org.springframework.data.mongodb.core.query.Query
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,17 +11,23 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class SmokingAreaFinder(
     private val smokingAreaRepository: SmokingAreaRepository,
-    private val mongoTemplate: MongoTemplate,
-    private val kakaoClient: KakaoClient,
+    private val townCacheStore: TownCacheStore,
+    private val geocoder: Geocoder,
 ) {
     fun search(townName: SmokingArea.TownName? = null): List<SmokingArea> {
-        val query =
-            Query().apply {
-                townName?.let { Criteria.where("name").`is`(it) }
-            }
+        if (townName == null) {
+            val smokingAreas = smokingAreaRepository.findAll()
+            return geocoder.searchByAddress(smokingAreas)
+        }
 
-        val smokingAreas = mongoTemplate.find(query, SmokingArea::class.java)
-        return Geocoder(kakaoClient, smokingAreas).searchByAddress()
+        if (townCacheStore.hasKey(townName)) {
+            return townCacheStore.getValue(townName)
+        }
+
+        val smokingAreas = smokingAreaRepository.findAllByName(townName)
+        val smokingAreasWithCoordinate = geocoder.searchByAddress(smokingAreas)
+        townCacheStore.set(townName, smokingAreasWithCoordinate)
+        return smokingAreasWithCoordinate
     }
 
     fun findById(id: String): SmokingArea =

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaKey.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaKey.kt
@@ -1,0 +1,13 @@
+package com.hsik.smoking.domain.area
+
+import org.bson.types.ObjectId
+
+class SmokingAreaKey {
+    fun getKeyOfTown(townName: SmokingArea.TownName): String = "$KEY:town:$townName"
+
+    fun getKeyOfSmokingArea(smokingAreaId: ObjectId): String = "$KEY:smoking-area:$smokingAreaId"
+
+    companion object {
+        const val KEY = "smoking-area-api"
+    }
+}

--- a/src/main/kotlin/com/hsik/smoking/domain/area/TownCacheStore.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/TownCacheStore.kt
@@ -1,0 +1,53 @@
+package com.hsik.smoking.domain.area
+
+import com.hsik.smoking.util.fromJson
+import com.hsik.smoking.util.toJson
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class TownCacheStore(
+    private val stringRedisTemplate: StringRedisTemplate,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun hasKey(key: SmokingArea.TownName): Boolean {
+        val townRedisKey = SmokingAreaKey().getKeyOfTown(key)
+        try {
+            return stringRedisTemplate.hasKey(townRedisKey)
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache read failed: {}", townRedisKey, e)
+            throw Exception(e)
+        }
+    }
+
+    fun getValue(key: SmokingArea.TownName): List<SmokingArea> {
+        val townRedisKey = SmokingAreaKey().getKeyOfTown(key)
+        try {
+            val value = stringRedisTemplate.opsForValue().get(townRedisKey)
+            if (value.isNullOrBlank()) {
+                throw IllegalStateException("[CACHE] Redis does not have key : $townRedisKey")
+            }
+
+            return value.fromJson<List<SmokingArea>>()
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache read failed: {}", townRedisKey, e)
+            throw Exception(e)
+        }
+    }
+
+    fun set(
+        key: SmokingArea.TownName,
+        smokingAreasWithCoordinate: List<SmokingArea>,
+    ) {
+        val townRedisKey = SmokingAreaKey().getKeyOfTown(key)
+        try {
+            val result = stringRedisTemplate.opsForValue().setIfAbsent(townRedisKey, smokingAreasWithCoordinate.toJson())
+            logger.debug("[CACHE] Redis cache set key:{}, result: {}", townRedisKey, result)
+        } catch (e: Exception) {
+            logger.error("[CACHE] Redis cache set failed: {}", townRedisKey, e)
+            throw Exception(e)
+        }
+    }
+}

--- a/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -24,7 +25,9 @@ class SmokingAreaController(
     private val smokingAreaSyncService: SmokingAreaSyncService,
 ) {
     @GetMapping
-    fun search(townName: SmokingArea.TownName? = null): Replies<SmokingAreaResources.Response.Me> {
+    fun search(
+        @RequestParam townName: SmokingArea.TownName? = null,
+    ): Replies<SmokingAreaResources.Response.Me> {
         val areas = smokingAreaFinder.search(townName)
         return SmokingAreaResources.Response.Me
             .from(areas)

--- a/src/main/kotlin/com/hsik/smoking/domain/area/repository/SmokingAreaRepository.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/repository/SmokingAreaRepository.kt
@@ -4,4 +4,6 @@ import com.hsik.smoking.domain.area.SmokingArea
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface SmokingAreaRepository : MongoRepository<SmokingArea, ObjectId>
+interface SmokingAreaRepository : MongoRepository<SmokingArea, ObjectId> {
+    fun findAllByName(name: SmokingArea.TownName): List<SmokingArea>
+}

--- a/src/main/kotlin/com/hsik/smoking/util/Jackson.kt
+++ b/src/main/kotlin/com/hsik/smoking/util/Jackson.kt
@@ -2,18 +2,27 @@ package com.hsik.smoking.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.bson.types.ObjectId
 
 object Jackson {
     private val mapper =
         ObjectMapper()
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .registerModule(JavaTimeModule())
+            .registerModules(JavaTimeModule(), objectIdModule())
             .registerKotlinModule()
 
     fun getMapper(): ObjectMapper = mapper
+}
+
+private fun objectIdModule(): SimpleModule {
+    val module = SimpleModule()
+    module.addSerializer(ObjectId::class.java, ToStringSerializer())
+    return module
 }
 
 fun <T> T.toJson(): String = Jackson.getMapper().writeValueAsString(this)

--- a/src/test/kotlin/com/hsik/smoking/config/FlowTest.kt
+++ b/src/test/kotlin/com/hsik/smoking/config/FlowTest.kt
@@ -13,7 +13,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @AutoConfigureMockMvc
 @SpringBootTest(
-    classes = [SmokingApplication::class, MockMvcCustomizer::class],
+    classes = [SmokingApplication::class, MockMvcCustomizer::class, TestRedisConfiguration::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 )
 abstract class FlowTest {
@@ -21,7 +21,7 @@ abstract class FlowTest {
     lateinit var mockMvc: MockMvc
 
     companion object {
-        private val MONGO_CONTAINER: MongoDBContainer = MongoDBContainer("mongo:latest").withReuse(true)
+        private val MONGO_CONTAINER: MongoDBContainer = MongoDBContainer("mongo:latest")
 
         init {
             MONGO_CONTAINER.start()

--- a/src/test/kotlin/com/hsik/smoking/config/TestRedisConfiguration.kt
+++ b/src/test/kotlin/com/hsik/smoking/config/TestRedisConfiguration.kt
@@ -1,0 +1,29 @@
+package com.hsik.smoking.config
+
+import com.redis.testcontainers.RedisContainer
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+
+@TestConfiguration
+class TestRedisConfiguration {
+    private val port = REDIS_CONTAINER.getMappedPort(REDIS_PORT)
+
+    @Bean
+    fun stringRedisTemplate(): StringRedisTemplate {
+        val configuration = RedisStandaloneConfiguration("localhost", port)
+        val factory = LettuceConnectionFactory(configuration).apply { afterPropertiesSet() }
+        return StringRedisTemplate(factory)
+    }
+
+    companion object {
+        private const val REDIS_PORT = 6379
+        private val REDIS_CONTAINER = RedisContainer("redis:7.4.1-alpine")
+
+        init {
+            REDIS_CONTAINER.start()
+        }
+    }
+}

--- a/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaCachingTest.kt
+++ b/src/test/kotlin/com/hsik/smoking/domain/area/api/SmokingAreaCachingTest.kt
@@ -1,0 +1,142 @@
+package com.hsik.smoking.domain.area.api
+
+import com.hsik.smoking.config.FlowTest
+import com.hsik.smoking.domain.area.SmokingArea
+import com.hsik.smoking.domain.area.SmokingAreaCacheStore
+import com.hsik.smoking.domain.area.SmokingAreaKey
+import com.hsik.smoking.domain.area.TownCacheStore
+import com.ninjasquad.springmockk.SpykBean
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.StringRedisTemplate
+
+class SmokingAreaCachingTest : FlowTest() {
+    @Autowired
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+
+    @SpykBean
+    private lateinit var smokingAreaCacheStore: SmokingAreaCacheStore
+
+    @SpykBean
+    private lateinit var townCacheStore: TownCacheStore
+
+    @Nested
+    inner class TownCachingTest {
+        @DisplayName("전체 흡연 구역 조회 시 캐싱된 데이터가 존재하지 않을 경우 모두 Cache Miss 및 Cache Save")
+        @Test
+        fun allCacheMissAndSave() {
+            // Given
+            // 기존 캐싱 데이터 삭제
+            val keys = stringRedisTemplate.keys("*")
+            keys.forEach { stringRedisTemplate.delete(it) }
+
+            // 흡연 구역 생성
+            val smokingAreaControllerFlow = SmokingAreaControllerFlow(mockMvc)
+            smokingAreaControllerFlow.sync(SmokingArea.TownName.DONGDAEMUN_GU)
+
+            // When
+            val smokingAreaCount = smokingAreaControllerFlow.search().count()
+
+            // Then
+            verify(exactly = smokingAreaCount) { smokingAreaCacheStore.set(any(), any()) }
+        }
+
+        @DisplayName("전체 흡연 구역 조회 시 SmokingArea가 모두 캐싱되었을 경우 모두 Cache Hit ")
+        @Test
+        fun allCacheHitBySmokingArea() {
+            // Given
+            // 기존 캐싱 데이터 삭제
+            val keys = stringRedisTemplate.keys("*")
+            keys.forEach { stringRedisTemplate.delete(it) }
+
+            // 흡연 구역 생성
+            val smokingAreaControllerFlow = SmokingAreaControllerFlow(mockMvc)
+            smokingAreaControllerFlow.sync(SmokingArea.TownName.DONGDAEMUN_GU)
+
+            // 데이터 캐싱
+            smokingAreaControllerFlow.search()
+
+            // When
+            val smokingAreaCount = smokingAreaControllerFlow.search().count()
+
+            // Then
+            verify(exactly = smokingAreaCount) { smokingAreaCacheStore.getValue(any()) }
+        }
+
+        @DisplayName("특정 구역의 흡연 구역 조회 시 Town이 캐싱되었을 경우 모두 Cache Hit ")
+        @Test
+        fun allCacheHitByTown() {
+            // Given
+            // 기존 캐싱 데이터 삭제
+            val keys = stringRedisTemplate.keys("*")
+            keys.forEach { stringRedisTemplate.delete(it) }
+
+            // 흡연 구역 생성
+            val smokingAreaControllerFlow = SmokingAreaControllerFlow(mockMvc)
+            val townName = SmokingArea.TownName.DONGDAEMUN_GU
+            smokingAreaControllerFlow.sync(townName)
+
+            // 데이터 캐싱
+            smokingAreaControllerFlow.search(townName)
+
+            // When
+            smokingAreaControllerFlow.search(townName).count()
+
+            // Then
+            verify(exactly = 1) { townCacheStore.getValue(any()) }
+        }
+    }
+
+    @Nested
+    inner class SmokingAreaCachingTest {
+        @DisplayName("흡연 구역 조회 시 캐싱된 데이터가 존재하지 않을 경우 모두 Cache Miss 및 Cache Save")
+        @Test
+        fun allCacheMissAndSave() {
+            // Given
+            // 기존 캐싱 데이터 삭제
+            val keys = stringRedisTemplate.keys("*")
+            keys.forEach { stringRedisTemplate.delete(it) }
+
+            // 흡연 구역 생성
+            val townName = SmokingArea.TownName.DONGDAEMUN_GU
+            val smokingAreaControllerFlow = SmokingAreaControllerFlow(mockMvc)
+            smokingAreaControllerFlow.sync(townName)
+
+            // When
+            val smokingAreaCount = smokingAreaControllerFlow.search(townName).count()
+
+            // Then
+            verify(exactly = smokingAreaCount) { smokingAreaCacheStore.set(any(), any()) }
+        }
+
+        @DisplayName("흡연 구역 조회 시 SmokingArea가 모두 캐싱되었을 경우 모두 Cache Hit ")
+        @Test
+        fun allCacheHitBySmokingArea() {
+            // Given
+            // 기존 캐싱 데이터 삭제
+            val keys = stringRedisTemplate.keys("*")
+            keys.forEach { stringRedisTemplate.delete(it) }
+
+            // 흡연 구역 생성
+            val townName = SmokingArea.TownName.DONGDAEMUN_GU
+            val smokingAreaControllerFlow = SmokingAreaControllerFlow(mockMvc)
+            smokingAreaControllerFlow.sync(townName)
+
+            // 데이터 캐싱
+            smokingAreaControllerFlow.search(townName)
+
+            // 타운 캐시 데이터 삭제
+            val townKeys = stringRedisTemplate.keys(SmokingAreaKey().getKeyOfTown(townName))
+            townKeys.forEach { stringRedisTemplate.delete(it) }
+
+            // When
+            val smokingAreaCount = smokingAreaControllerFlow.search(townName).count()
+
+            // Then
+            verify(exactly = smokingAreaCount) { smokingAreaCacheStore.getValue(any()) }
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,8 +30,6 @@ spring:
     lazy-initialization: true
   data:
     mongodb:
-      uri: mongodb://localhost:9064
-      database: smoking
       auto-index-creation: true
 
 springdoc:


### PR DESCRIPTION
# What?
SmokingArea 엔티티의 위, 경도 필드에 카카오 로컬 API로 받은 위, 경도를 저장하고, 레디스에 SmokingArea를 저장합니다.

# Why?
오픈 데이터 포탈에서 흡연 구역들의 주소는 제공하지만, 좌표는 제공하지 않아 카카오의 로컬 API를 사용합니다.

한 지역의 흡연 구역들은 100개 이상이 되어서 지도를 사용자에게 보여줄 때마다 100번 이상의 로컬 API를 호출해야 하는데요. 
이렇게 된다면 사용자 경험이 너무 떨어지기에 레디스에 결과를 캐싱합니다.