### PR TITLE
캐시 데이터 TTL 설정

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaCacheStore.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaCacheStore.kt
@@ -6,6 +6,7 @@ import org.bson.types.ObjectId
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class SmokingAreaCacheStore(
@@ -44,7 +45,10 @@ class SmokingAreaCacheStore(
     ) {
         val smokingAreaRedisKey = SmokingAreaKey().getKeyOfSmokingArea(key)
         try {
-            val result = stringRedisTemplate.opsForValue().setIfAbsent(smokingAreaRedisKey, smokingArea.toJson())
+            val result =
+                stringRedisTemplate
+                    .opsForValue()
+                    .setIfAbsent(smokingAreaRedisKey, smokingArea.toJson(), Duration.ofHours(1L))
             logger.debug("[CACHE] Redis cache set key:{}, result: {}", smokingAreaRedisKey, result)
         } catch (e: Exception) {
             logger.error("[CACHE] Redis cache set failed: {}", smokingAreaRedisKey, e)

--- a/src/main/kotlin/com/hsik/smoking/domain/area/TownCacheStore.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/TownCacheStore.kt
@@ -5,6 +5,7 @@ import com.hsik.smoking.util.toJson
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class TownCacheStore(
@@ -43,7 +44,10 @@ class TownCacheStore(
     ) {
         val townRedisKey = SmokingAreaKey().getKeyOfTown(key)
         try {
-            val result = stringRedisTemplate.opsForValue().setIfAbsent(townRedisKey, smokingAreasWithCoordinate.toJson())
+            val result =
+                stringRedisTemplate
+                    .opsForValue()
+                    .setIfAbsent(townRedisKey, smokingAreasWithCoordinate.toJson(), Duration.ofHours(1L))
             logger.debug("[CACHE] Redis cache set key:{}, result: {}", townRedisKey, result)
         } catch (e: Exception) {
             logger.error("[CACHE] Redis cache set failed: {}", townRedisKey, e)


### PR DESCRIPTION
# Why?
카카오의 운영 정책을 지키기 위해 캐싱에 TTL을 적용했습니다.

사용자 경험을 증대시키기 위해 캐싱을 적용했습니다.
혹시 카카오 API를 사용할 때 데이터를 캐싱하는 것이 카카오의 운영 정책을 위반하는 것인지 혹시 몰라 확인해봤습니다.

카카오 운영 정책에선
> 20. 앱에서 사용자 환경을 개선하기 위한 목적 외 다른 목적으로 카카오에서 받은 데이터를 캐시하거나 캐시 후 최신 데이터로 유지하지 않는 행위

라고 나와있었습니다.

기존에는 캐시 데이터를 전혀 만료시키지 않았기 떄문에 TTL을 설정했습니다.

혹시 캐싱 기간도 문제가 되는지 카카오 측에 문의해보았으며, 1~2시간 이내라면 괜찮다는 답변을 받았습니다.
![스크린샷 2024-10-19 오후 9 40 54](https://github.com/user-attachments/assets/dd284832-9269-43f7-b68f-e7866d5b0fa8)

그래서 TTL을 1시간으로 설정했습니다.
