### PR TITLE
흡연 구역 싱크 시 Document Replace 작업 실패 오류 수정

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/domain/area/Geocoder.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/Geocoder.kt
@@ -11,8 +11,8 @@ class Geocoder(
     fun searchByAddress(smokingAreas: List<SmokingArea>): List<SmokingArea> {
         for (smokingArea in smokingAreas) {
             // Use cache data if exists
-            if (smokingAreaCacheStore.hasKey(smokingArea.id)) {
-                val cachedSmokingArea = smokingAreaCacheStore.getValue(smokingArea.id)
+            if (smokingAreaCacheStore.hasKey(smokingArea.id!!)) {
+                val cachedSmokingArea = smokingAreaCacheStore.getValue(smokingArea.id!!)
                 smokingArea.latitude = cachedSmokingArea.latitude!!.toDouble()
                 smokingArea.longitude = cachedSmokingArea.longitude!!.toDouble()
                 continue
@@ -27,7 +27,7 @@ class Geocoder(
                 }
 
             // Store data in cache
-            smokingAreaCacheStore.set(smokingArea.id, smokingArea)
+            smokingAreaCacheStore.set(smokingArea.id!!, smokingArea)
         }
         return smokingAreas
     }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingArea.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingArea.kt
@@ -32,7 +32,7 @@ class SmokingArea(
     var metadataUpdateDateTime: String? = null,
 ) {
     @Id
-    var id: ObjectId = ObjectId()
+    var id: ObjectId? = null
         private set
 
     /**

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaService.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaService.kt
@@ -17,6 +17,6 @@ class SmokingAreaService(
                 name = name,
                 address = address,
             )
-        return smokingAreaRepository.save(area).id
+        return smokingAreaRepository.save(area).id!!
     }
 }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaSyncService.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaSyncService.kt
@@ -12,7 +12,11 @@ class SmokingAreaSyncService(
     fun sync(name: SmokingArea.TownName) {
         val synchronizer =
             when (name) {
-                SmokingArea.TownName.DONGDAEMUN_GU -> DongdaemunGuSynchronizer(openDataPortalClient, smokingAreaTemplate)
+                SmokingArea.TownName.DONGDAEMUN_GU ->
+                    DongdaemunGuSynchronizer(
+                        openDataPortalClient,
+                        smokingAreaTemplate,
+                    )
             }
         synchronizer.synchronize()
     }

--- a/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaTemplate.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/area/SmokingAreaTemplate.kt
@@ -28,6 +28,7 @@ class SmokingAreaTemplate(
             val query =
                 Query().apply {
                     addCriteria(Criteria.where(SmokingArea::referenceId.name).`is`(it.referenceId))
+                    addCriteria(Criteria.where(SmokingArea::name.name).`is`(it.name))
                 }
 
             val document =

--- a/src/main/kotlin/com/hsik/smoking/domain/client/government/OpenDataPortalResources.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/client/government/OpenDataPortalResources.kt
@@ -11,16 +11,16 @@ class OpenDataPortalResources {
             val type: String,
             @JsonAlias("설치위치")
             val address: String,
-            @JsonAlias("규모")
-            val size: String,
-            @JsonAlias("설치년도")
-            val buildAt: String,
             @JsonAlias("설치주체")
             val builtBy: String,
             @JsonAlias("운영관리")
             val manager: String,
             @JsonAlias("데이터기준일자")
             val metadataUpdateDateTime: String,
+            @JsonAlias("규모")
+            val size: String? = null,
+            @JsonAlias("설치년도")
+            val buildAt: String? = null,
         )
     }
 }

--- a/src/main/kotlin/com/hsik/smoking/domain/client/government/StableOpenDataPortalClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/domain/client/government/StableOpenDataPortalClient.kt
@@ -10,8 +10,14 @@ class StableOpenDataPortalClient(
     private val restClient: RestClient,
 ) : OpenDataPortalClient {
     override fun findAllSmokingAreaInDongdaemunGu(): List<OpenDataPortalResources.SmokingArea.DongdaemunGu> {
-        // Authorization 헤더에 인증키를 담아 보낼 경우 오픈 데이터 포털에서 인식하지 못하므로 Query로 전달
-        val params = listOf("serviceKey" to env.apiKey)
+        val params =
+            listOf(
+                // Authorization 헤더에 인증키를 담아 보낼 경우 오픈 데이터 포털에서 인식하지 못하므로 Query로 전달
+                "serviceKey" to env.apiKey,
+                // 동대문구 흡연 시설 정보는 110개이며, perPage 기본값은 10
+                // 전체 110개를 받을 수 있도록 perPage를 1000으로 설정 후 전송
+                "perPage" to 1000,
+            )
         val uri = "${env.host}/api/15070168/v1/uddi:04b20c76-3628-4095-93bb-8e9523a1241a"
         return restClient
             .get(uri, null, params)

--- a/src/main/kotlin/com/hsik/smoking/util/RestClient.kt
+++ b/src/main/kotlin/com/hsik/smoking/util/RestClient.kt
@@ -17,7 +17,7 @@ class RestClient(
     fun get(
         url: String,
         headers: List<Pair<String, String>>? = null,
-        params: List<Pair<String, String>>? = null,
+        params: List<Pair<String, Any>>? = null,
     ): String {
         val query = params?.joinToString("&") { "${it.first}=${it.second}" }
         val uri = if (query.isNullOrBlank()) url else "$url?$query"


### PR DESCRIPTION
# What?
ID 필드의 기본 값을 null로 변경

# Why?
### 예외 발생
흡연 구역 싱크 시 다음과 같은 예외가 발생했습니다.
> After applying the update, the (immutable) field '_id' was found to have been altered to _id: ObjectId('...)

### 원인 분석
해당 예외는 **MongoDB의 `_id` 필드는 불변(immutable)** 이어야 하는데, 이를 변경하려고 시도했기 때문에 발생한 것입니다. 오류 메시지에서 확인할 수 있듯이, MongoDB는 업데이트를 적용한 후에 _id 필드가 변경되었습니다. 이로 인해 BulkWriteError 예외가 발생하고 있습니다. 

예를 들어 다음과 같습니다.
A Document의 ID가 1234이고, B Document의 ID가 4567일 때 A Document를 B Document로 교체한다면,
A Document의 ID가 1234에서 4567로 교체되어야 합니다.
이미 Document의 ID가 1234로 설정되어있는데 다른 ID로 변경하려고 해서 예외가 발생합니다.

### 문제 해결
ID 필드를 교체 대상에서 제외합니다.

SmokingArea의 id 필드의 기본 값을 null로 설정합니다.
replaceOne 메소드로 A Document를 B Document로 교체할 때, 만약 B Docuement의 ID가 존재할 경우 A Document의 ID도 B Document의 ID로 교체합니다.

즉 aDocument.id = bDocument.id가 됩니다.
하지만 ID가 null일 경우 해당 교체 대상에서 제외하여 ID를 교체하지 않습니다.

이건 ID만 해당되며, 다른 프로퍼티의 경우 null 이든 아니든 해당 값을 그대로 교체합니다.
예를 들어 name 필드를 변경한다고 하면,
aDocument.name = bDocument.name 이 됩니다.