### PR TITLE
Naver ClientID 설정

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
     <title>Smoking Area</title>
-    <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=test0101"></script>
+    <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=m9b7lkyrot"></script>
     <script type="module" src="map.js"></script>
     <link rel="stylesheet" type="text/css" href="style.css"/>
     <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.0/css/line.css">


### PR DESCRIPTION
브라우저에서 네이버 지도를 띄우기 위해 사용되는 Naver Client ID를 작성한다.
Naver API는 지정한 도메인에서만 호출 가능하기 때문에 해당 ClientID는 노출되어도 상관없다.