### PR TITLE
HTTP Request 및 Response 로깅 필터 구현

### DIFF
--- a/src/main/kotlin/com/hsik/smoking/config/FilterConfiguration.kt
+++ b/src/main/kotlin/com/hsik/smoking/config/FilterConfiguration.kt
@@ -1,0 +1,10 @@
+package com.hsik.smoking.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FilterConfiguration {
+    @Bean
+    fun requestResponseLogFilter(): RequestResponseLogFilter = RequestResponseLogFilter()
+}

--- a/src/main/kotlin/com/hsik/smoking/config/RequestResponseLogFilter.kt
+++ b/src/main/kotlin/com/hsik/smoking/config/RequestResponseLogFilter.kt
@@ -1,0 +1,79 @@
+package com.hsik.smoking.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.web.filter.OncePerRequestFilter
+
+class RequestResponseLogFilter : OncePerRequestFilter() {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val startTime = System.currentTimeMillis()
+        if (shouldLog(request)) {
+            try {
+                beforeRequest(request)
+                filterChain.doFilter(request, response)
+            } finally {
+                afterRequest(request, response, startTime)
+            }
+        } else {
+            filterChain.doFilter(request, response)
+        }
+    }
+
+    private fun shouldLog(request: HttpServletRequest): Boolean {
+        val uri = request.requestURI
+
+        return !(
+            uri == "/" ||
+                uri == "/style.css" ||
+                uri == "/map.js" ||
+                uri == "/api.js" ||
+                uri == "/config.js" ||
+                uri == "/favicon.ico"
+        )
+    }
+
+    private fun beforeRequest(request: HttpServletRequest) {
+        val message = StringBuilder()
+        message.append("[REQUEST] ${request.method} ${getUrl(request)} \n")
+
+        val headers = ServletServerHttpRequest(request).headers
+        for (header in headers) {
+            message.append("${header.key} : ${header.value} \n")
+        }
+
+        log.info(message.toString())
+    }
+
+    private fun afterRequest(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        startTime: Long,
+    ) {
+        val message = StringBuilder()
+        message
+            .append("[RESPONSE] ${request.method} ${getUrl(request)} ${response.status} ${HttpStatus.valueOf(response.status).name} \n")
+            .append("Duration : ${System.currentTimeMillis() - startTime}ms \n")
+
+        val headerNames = response.headerNames
+        for (headerName in headerNames) {
+            message.append("$headerName : ${response.getHeader(headerName)} \n")
+        }
+
+        log.info(message.toString())
+    }
+
+    private fun getUrl(request: HttpServletRequest): String {
+        val query = if (request.queryString.isNullOrBlank()) "" else "?${request.queryString}"
+        return "${request.requestURL}$query"
+    }
+}


### PR DESCRIPTION
### Why?
- 어플리케이션이 주고받는  HTTP Request 및 Response 를 확인하기 위해 추가

### 어째서 Spring이 제공하는 CommonsRequestLoggingFilter를 사용하지 않았나요?
- 해당 Filter는 이름에서 보이는 바와 같이 HTTP Request를 작성하는 필터이다. 또한, 해당 필터로 작성되는 로그는 보기 좋지 않다.
- 나는 어플리케이션이 전달하는 HTTP Response도 보고 싶었기 때문에 해당 필터를 사용하지 않고, 커스텀 Filter를 구현했다.

커스텀 필터를 구현 후 화면에 노출되는 로그는 다음과 같다.
```
2024-10-29T07:09:06.506+09:00  INFO 14289 --- [  XNIO-1 task-2] c.h.s.config.RequestResponseLogFilter    : [REQUEST] GET http://localhost:10500/v1/areas?townName=DONGDAEMUN_GU 
Cookie : [SL_G_WPT_TO=ko; SL_GWPT_Show_Hide_tmp=undefined; SL_wptGlobTipTmp=undefined; Idea-ee987c90=6f4de3cf-8b5a-4cd9-a4f5-33d4df4f5d13] 
User-Agent : [Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36] 
Connection : [keep-alive] 
Referer : [http://localhost:10500/swagger-ui/index.html] 
Sec-Fetch-Dest : [empty] 
Sec-Fetch-Site : [same-origin] 
Host : [localhost:10500] 
Accept-Encoding : [gzip, deflate, br, zstd] 
accept : [*/*] 
Sec-Fetch-Mode : [cors] 
sec-ch-ua : ["Google Chrome";v="129", "Not=A?Brand";v="8", "Chromium";v="129"] 
sec-ch-ua-mobile : [?0] 
sec-ch-ua-platform : ["macOS"] 
Accept-Language : [ko-KR,ko;q=0.9] 

2024-10-29T07:09:06.891+09:00  INFO 14289 --- [  XNIO-1 task-2] c.h.s.config.RequestResponseLogFilter    : [RESPONSE] GET http://localhost:10500/v1/areas?townName=DONGDAEMUN_GU 200 OK 
Duration : 388ms 
Transfer-Encoding : chunked 
Content-Encoding : gzip 
Connection : keep-alive 
Date : Mon, 28 Oct 2024 22:09:06 GMT 
Content-Type : application/json 
```